### PR TITLE
Update README.md to reflect lack of default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This command adds the react-native-react-query-devtools package to your project 
 ## Usage
 Incorporating React Query Dev Tools into your application is straightforward. Begin by importing the DevToolsBubble component.
 ```javascript
-import DevToolsBubble from 'react-native-react-query-devtools';
+import { DevToolsBubble } from 'react-native-react-query-devtools';
 ```
 
 Next, integrate the DevToolsBubble component into your app. A common practice is to render it at the root of your layout to ensure it's accessible throughout your app. However, you have the flexibility to place it wherever.


### PR DESCRIPTION
The `index.ts` file exports were at odds with the README.md. Alternatively, you can export default from `index.ts`